### PR TITLE
Change direction of newer/older in pagination

### DIFF
--- a/src/components/pagination/pagination.css
+++ b/src/components/pagination/pagination.css
@@ -1,0 +1,3 @@
+.pagination-newer-link {
+  float: right;
+}

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -1,16 +1,17 @@
 import React from "react";
 import { Link } from "gatsby";
+import './pagination.css';
 
 export default function Pagination({ prefix, page, pages }) {
   return (
     <div className="pagination">
-      {page > 1 ? (
-        <Link to={page === 2 ? prefix : `${prefix}/${page - 1}`}>
-          &larr; Newer
-        </Link>
-      ) : null}
       {page + 1 !== pages ? (
-        <Link to={`${prefix}/${page + 1}`}>Older &rarr;</Link>
+        <Link to={`${prefix}/${page + 1}`}>&larr; Older</Link>
+      ) : null}
+      {page > 1 ? (
+        <Link className="pagination-newer-link" to={page === 2 ? prefix : `${prefix}/${page - 1}`}>
+          Newer &rarr;
+        </Link>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Motivation

Originally, I just wanted to space out the Newer/Older links but then I found that their arrows don't make sense. `<-` should mean older, `->` is newer. Maybe because I'm right handed, but the other way is kinda weird for me.

## Approach

- Changed arrows and location of newer/older text.
- Made newer link spaced to the right 

## Screenshots

### Before

![2019-10-02 17 14 59](https://user-images.githubusercontent.com/74687/66082498-44666000-e538-11e9-82e7-d153c798930e.gif)

### After

![2019-10-02 17 13 09](https://user-images.githubusercontent.com/74687/66082511-49c3aa80-e538-11e9-9730-5915fd706f90.gif)

